### PR TITLE
Updated /client/src/setupTests.js so that we've globally imported Enz…

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,10 @@ Features:
 - Front and backend validation of forms and endpoints
 - Originally built using [CreateReactApp](https://github.com/facebook/create-react-app)
 
+Good to know:
+
+- The `/client/src/setupTests` file imports shallow, render, mount (from Enzyme) and React components globally for each test, meaning that we don't have to repeat those import statements in each individual test file.
+
 Requirements:
 
 - Node: tested on 8.4.0 
@@ -32,7 +36,7 @@ Requirements:
 
 - [Mongo](https://www.mongodb.com/download-center/community): tested on 4.0.0
 
-- A connection string - in ```src/config/keys_dev.js``` - in the following format
+- A config file under the directory `./src/config/keys_dev.js`, in the format shown below
 
 - [CreateReactApp](https://www.npmjs.com/package/create-react-app), if you wish to start the server and client concurrently without opening a new browser tab automatically (*See BROWSER=none in the scripts section of the package.json file*)
 

--- a/client/src/__tests__/App.unit.js
+++ b/client/src/__tests__/App.unit.js
@@ -1,10 +1,7 @@
-import React from 'react';
-import { mount } from 'enzyme';
 import { MemoryRouter } from 'react-router';
 import App from '../App';
 import Landing from '../components/layout/Landing';
 import Login from '../components/auth/Login';
-import { mockStore } from '../__mocks__/mockStore';
 // import jwt_decode from 'jwt-decode';
 import * as jwt_decode from 'jwt-decode';
 

--- a/client/src/actions/__tests__/authActions.js
+++ b/client/src/actions/__tests__/authActions.js
@@ -1,7 +1,6 @@
 import mockAxios from 'axios';
 import * as actions from '../authActions';
 import * as types from '../types';
-import { mockStore } from '../../__mocks__/mockStore';
 
 jest.mock('jwt-decode', () => jest.fn().mockReturnValue({
   exp: 12345

--- a/client/src/actions/__tests__/postActions.js
+++ b/client/src/actions/__tests__/postActions.js
@@ -1,7 +1,6 @@
 import mockAxios from 'axios';
 import * as actions from '../postActions'
 import * as types from '../types';
-import { mockStore } from '../../__mocks__/mockStore';
 import { mockPosts, newPost, deletedPostId } from '../../__mocks__/mockPosts';
 import { idCannotBeNullExceptionMessage } from '../../__mocks__/exceptionMessages';
 

--- a/client/src/actions/__tests__/profileActions.js
+++ b/client/src/actions/__tests__/profileActions.js
@@ -1,7 +1,6 @@
 import mockAxios from 'axios';
 import * as actions from '../profileActions'
 import * as types from '../types';
-import { mockStore } from '../../__mocks__/mockStore';
 
 let store;
 let storeActions;

--- a/client/src/components/add-credentials/__tests__/AddEducation.int.js
+++ b/client/src/components/add-credentials/__tests__/AddEducation.int.js
@@ -1,10 +1,7 @@
-import React from 'react';
-import { mount } from 'enzyme';
 import { MemoryRouter } from 'react-router-dom';
 import { Provider } from 'react-redux';
 import ConnectedAddEducation from '../AddEducation';
 import event from '../../../__mocks__/event';
-import { mockStore } from '../../../__mocks__/mockStore';
 
 const errors = {};
 let mockState = {

--- a/client/src/components/add-credentials/__tests__/AddEducation.unit.js
+++ b/client/src/components/add-credentials/__tests__/AddEducation.unit.js
@@ -1,5 +1,3 @@
-import React from 'react';
-import { shallow } from 'enzyme';
 import { AddEducation } from '../AddEducation';
 
 const addEducation = jest.fn();

--- a/client/src/components/add-credentials/__tests__/AddExperience.int.js
+++ b/client/src/components/add-credentials/__tests__/AddExperience.int.js
@@ -1,10 +1,7 @@
-import React from 'react';
-import { mount } from 'enzyme';
 import { MemoryRouter } from 'react-router-dom';
 import { Provider } from 'react-redux';
 import ConnectedAddExperience from '../AddExperience';
 import event from '../../../__mocks__/event';
-import { mockStore } from '../../../__mocks__/mockStore';
 
 const errors = {};
 let mockState = {

--- a/client/src/components/add-credentials/__tests__/AddExperience.unit.js
+++ b/client/src/components/add-credentials/__tests__/AddExperience.unit.js
@@ -1,5 +1,3 @@
-import React from 'react';
-import { shallow } from 'enzyme';
 import { AddExperience } from '../AddExperience';
 
 const addExperience = jest.fn();

--- a/client/src/components/auth/__tests__/Login.int.js
+++ b/client/src/components/auth/__tests__/Login.int.js
@@ -1,7 +1,4 @@
-import React from 'react';
-import { mount } from 'enzyme';
 import ConnectedLogin from '../Login';
-import { mockStore } from '../../../__mocks__/mockStore';
 import { mockIsNotAuthState } from '../../../__mocks__/mockAuth';
 
 const loginUser = jest.fn();

--- a/client/src/components/auth/__tests__/Login.unit.js
+++ b/client/src/components/auth/__tests__/Login.unit.js
@@ -1,7 +1,4 @@
-import React from 'react';
-import { shallow } from 'enzyme';
 import ConnectedLogin, { Login } from '../Login';
-import { mockStore } from '../../../__mocks__/mockStore';
 import { mockIsAuthState, mockIsNotAuthState } from '../../../__mocks__/mockAuth';
 
 const loginUser = jest.fn();

--- a/client/src/components/auth/__tests__/Register.int.js
+++ b/client/src/components/auth/__tests__/Register.int.js
@@ -1,7 +1,4 @@
-import React from 'react';
-import { mount } from 'enzyme';
 import ConnectedRegister from '../Register';
-import { mockStore } from '../../../__mocks__/mockStore';
 import { mockIsNotAuthState } from '../../../__mocks__/mockAuth';
 
 const isNotAuthState = {

--- a/client/src/components/auth/__tests__/Register.unit.js
+++ b/client/src/components/auth/__tests__/Register.unit.js
@@ -1,7 +1,4 @@
-import React from 'react';
-import { shallow } from 'enzyme';
 import ConnectedRegister, { Register } from '../Register';
-import { mockStore } from '../../../__mocks__/mockStore';
 import { mockIsAuthState, mockIsNotAuthState } from '../../../__mocks__/mockAuth';
 
 const registerUser = jest.fn();

--- a/client/src/components/common/__tests__/PrivateRoute.unit.js
+++ b/client/src/components/common/__tests__/PrivateRoute.unit.js
@@ -1,5 +1,3 @@
-import React from 'react';
-import { shallow } from 'enzyme';
 import { PrivateRoute } from '../PrivateRoute';
 import { mockAuth } from '../../../__mocks__/mockAuth';
 

--- a/client/src/components/dashboard/__tests__/Dashboard.int.js
+++ b/client/src/components/dashboard/__tests__/Dashboard.int.js
@@ -1,10 +1,8 @@
-import React from 'react';
-import { mount } from 'enzyme';
+
 import { BrowserRouter as Router } from 'react-router-dom';
 import { Provider } from 'react-redux';
 import ConnectedDashboard, { Dashboard } from '../Dashboard';
 import { mockProfiles } from '../../../__mocks__/mockProfiles';
-import { mockStore } from '../../../__mocks__/mockStore';
 
 const deleteAccount = jest.fn();
 const { user: { name } } = mockProfiles[0];

--- a/client/src/components/dashboard/__tests__/Dashboard.unit.js
+++ b/client/src/components/dashboard/__tests__/Dashboard.unit.js
@@ -1,7 +1,4 @@
-import React from 'react';
-import { shallow } from 'enzyme';
 import ConnectedDashboard from '../Dashboard';
-import { mockStore } from '../../../__mocks__/mockStore';
 import { mockProfiles } from '../../../__mocks__/mockProfiles';
 
 const { user: { name } } = mockProfiles[0];

--- a/client/src/components/dashboard/__tests__/Education.int.js
+++ b/client/src/components/dashboard/__tests__/Education.int.js
@@ -1,6 +1,3 @@
-import React from 'react';
-import { mount } from 'enzyme';
-import toJson from 'enzyme-to-json';
 import { Education } from '../Education';
 import { mockEducation } from '../../../__mocks__/mockEducation.js';
 

--- a/client/src/components/dashboard/__tests__/Education.unit.js
+++ b/client/src/components/dashboard/__tests__/Education.unit.js
@@ -1,6 +1,3 @@
-import React from 'react';
-import { shallow } from 'enzyme';
-import toJson from 'enzyme-to-json';
 import { Education } from '../Education';
 import { mockEducation } from '../../../__mocks__/mockEducation.js';
 

--- a/client/src/components/dashboard/__tests__/Experience.int.js
+++ b/client/src/components/dashboard/__tests__/Experience.int.js
@@ -1,5 +1,3 @@
-import React from 'react';
-import { mount } from 'enzyme';
 import { Experience } from '../Experience';
 import { mockExperience } from '../../../__mocks__/mockExperience.js';
 

--- a/client/src/components/layout/__tests__/Footer.unit.js
+++ b/client/src/components/layout/__tests__/Footer.unit.js
@@ -1,5 +1,3 @@
-import { shallow } from 'enzyme';
-import React from 'react';
 import Footer from '../Footer';
 
 it('expect to render Footer component', () => {

--- a/client/src/components/layout/__tests__/Landing.unit.js
+++ b/client/src/components/layout/__tests__/Landing.unit.js
@@ -1,7 +1,4 @@
-import React from 'react';
-import { shallow } from 'enzyme';
 import Landing from '../Landing';
-import { mockStore } from '../../../__mocks__/mockStore';
 import { mockIsAuthState, mockIsNotAuthState } from '../../../__mocks__/mockAuth';
 
 const push = jest.fn();

--- a/client/src/components/layout/__tests__/Navbar.unit.js
+++ b/client/src/components/layout/__tests__/Navbar.unit.js
@@ -1,6 +1,3 @@
-import React from 'react';
-import { shallow } from 'enzyme';
-import toJson from 'enzyme-to-json';
 import { Navbar } from '../Navbar';
 import { mockProfiles } from '../../../__mocks__/mockProfiles';
 

--- a/client/src/components/post/__tests__/CommentFeed.unit.js
+++ b/client/src/components/post/__tests__/CommentFeed.unit.js
@@ -1,5 +1,3 @@
-import React from 'react';
-import { shallow } from 'enzyme';
 import { CommentFeed } from '../CommentFeed';
 import { mockPosts } from '../../../__mocks__/mockPosts';
 

--- a/client/src/components/post/__tests__/CommentForm.int.js
+++ b/client/src/components/post/__tests__/CommentForm.int.js
@@ -1,10 +1,7 @@
-import React from 'react';
-import { mount } from 'enzyme';
 import { BrowserRouter as Router } from 'react-router-dom';
 import { Provider } from 'react-redux';
 import ConnectedCommentForm from '../CommentForm';
 import event from '../../../__mocks__/event';
-import { mockStore } from '../../../__mocks__/mockStore';
 import { mockAuth } from '../../../__mocks__/mockAuth';
 import { mockPosts } from '../../../__mocks__/mockPosts';
 

--- a/client/src/components/post/__tests__/CommentForm.unit.js
+++ b/client/src/components/post/__tests__/CommentForm.unit.js
@@ -1,5 +1,3 @@
-import React from 'react';
-import { shallow } from 'enzyme';
 import { CommentForm } from '../CommentForm';
 import { mockAuth } from '../../../__mocks__/mockAuth';
 import { mockPosts } from '../../../__mocks__/mockPosts';

--- a/client/src/components/post/__tests__/CommentItem.int.js
+++ b/client/src/components/post/__tests__/CommentItem.int.js
@@ -1,5 +1,3 @@
-import React from 'react';
-import { mount } from 'enzyme';
 import { CommentItem } from '../CommentItem';
 import { mockPosts } from '../../../__mocks__/mockPosts';
 import { mockAuth } from '../../../__mocks__/mockAuth';

--- a/client/src/components/post/__tests__/CommentItem.unit.js
+++ b/client/src/components/post/__tests__/CommentItem.unit.js
@@ -1,5 +1,3 @@
-import React from 'react';
-import { shallow } from 'enzyme';
 import { CommentItem } from '../CommentItem';
 import { mockPosts } from '../../../__mocks__/mockPosts';
 import { mockAuth } from '../../../__mocks__/mockAuth';

--- a/client/src/components/post/__tests__/Post.unit.js
+++ b/client/src/components/post/__tests__/Post.unit.js
@@ -1,5 +1,3 @@
-import React from 'react';
-import { shallow } from 'enzyme';
 import { Post } from '../Post';
 import { mockPosts } from '../../../__mocks__/mockPosts';
 

--- a/client/src/components/posts/__tests__/PostFeed.unit.js
+++ b/client/src/components/posts/__tests__/PostFeed.unit.js
@@ -1,5 +1,3 @@
-import React from 'react';
-import { shallow } from 'enzyme';
 import { PostFeed } from '../PostFeed';
 import { mockPosts } from '../../../__mocks__/mockPosts';
 

--- a/client/src/components/posts/__tests__/PostForm.int.js
+++ b/client/src/components/posts/__tests__/PostForm.int.js
@@ -1,10 +1,7 @@
-import React from 'react';
-import { mount } from 'enzyme';
 import { BrowserRouter as Router } from 'react-router-dom';
 import { Provider } from 'react-redux';
 import ConnectedPostForm from '../PostForm';
 import event from '../../../__mocks__/event';
-import { mockStore } from '../../../__mocks__/mockStore';
 import { mockAuth } from '../../../__mocks__/mockAuth';
 
 const errors = {};

--- a/client/src/components/posts/__tests__/PostForm.unit.js
+++ b/client/src/components/posts/__tests__/PostForm.unit.js
@@ -1,5 +1,3 @@
-import React from 'react';
-import { shallow } from 'enzyme';
 import { PostForm } from '../PostForm';
 import { mockAuth } from '../../../__mocks__/mockAuth';
 

--- a/client/src/components/posts/__tests__/PostItem.int.js
+++ b/client/src/components/posts/__tests__/PostItem.int.js
@@ -1,5 +1,3 @@
-import React from 'react';
-import { mount } from 'enzyme';
 import { PostItem } from '../PostItem';
 import { mockPosts } from '../../../__mocks__/mockPosts';
 import { mockAuth } from '../../../__mocks__/mockAuth';

--- a/client/src/components/posts/__tests__/PostItem.unit.js
+++ b/client/src/components/posts/__tests__/PostItem.unit.js
@@ -1,5 +1,3 @@
-import React from 'react';
-import { shallow } from 'enzyme';
 import { PostItem } from '../PostItem';
 import { mockPosts, likesListToTriggerFalsy } from '../../../__mocks__/mockPosts';
 import { mockAuth } from '../../../__mocks__/mockAuth';

--- a/client/src/components/posts/__tests__/Posts.int.js
+++ b/client/src/components/posts/__tests__/Posts.int.js
@@ -1,9 +1,6 @@
-import React from 'react';
-import { mount } from 'enzyme';
 import { MemoryRouter } from 'react-router-dom';
 import { Provider } from 'react-redux';
 import ConnectedPosts from '../Posts';
-import { mockStore } from '../../../__mocks__/mockStore';
 import { mockAuth } from '../../../__mocks__/mockAuth';
 import { mockPosts } from '../../../__mocks__/mockPosts';
 

--- a/client/src/components/posts/__tests__/Posts.unit.js
+++ b/client/src/components/posts/__tests__/Posts.unit.js
@@ -1,5 +1,3 @@
-import React from 'react';
-import { shallow } from 'enzyme';
 import { Posts } from '../Posts';
 import { mockPosts } from '../../../__mocks__/mockPosts';
 

--- a/client/src/components/profile/__tests__/Profile.int.js
+++ b/client/src/components/profile/__tests__/Profile.int.js
@@ -1,9 +1,6 @@
-// import React from 'react';
-// import { mount } from 'enzyme';
 // import { BrowserRouter as Router } from 'react-router-dom';
 // import { Provider } from 'react-redux';
 // import ConnectedProfile from '../Profile';
-// import { mockStore } from '../../../__mocks__/mockStore';
 // // import { mockIsNotAuthState } from '../../../__mocks__/mockAuth';
 
 // const getProfileByHandle = jest.fn();

--- a/client/src/components/profile/__tests__/Profile.unit.js
+++ b/client/src/components/profile/__tests__/Profile.unit.js
@@ -1,5 +1,3 @@
-import React from 'react';
-import { shallow } from 'enzyme';
 import { Profile } from '../Profile';
 import { mockProfiles } from '../../../__mocks__/mockProfiles';
 

--- a/client/src/components/profile/__tests__/ProfileAbout.unit.js
+++ b/client/src/components/profile/__tests__/ProfileAbout.unit.js
@@ -1,5 +1,3 @@
-import React from 'react';
-import { shallow } from 'enzyme';
 import ProfileAbout from '../ProfileAbout';
 import { mockProfiles } from '../../../__mocks__/mockProfiles';
 

--- a/client/src/components/profile/__tests__/ProfileCreds.unit.js
+++ b/client/src/components/profile/__tests__/ProfileCreds.unit.js
@@ -1,5 +1,3 @@
-import React from 'react';
-import { shallow } from 'enzyme';
 import ProfileCreds from '../ProfileCreds';
 import { mockExperience, mockExpNoCompanyOrLocation } from '../../../__mocks__/mockExperience';
 import { mockEducation } from '../../../__mocks__/mockEducation';

--- a/client/src/components/profile/__tests__/ProfileGithub.unit.js
+++ b/client/src/components/profile/__tests__/ProfileGithub.unit.js
@@ -1,5 +1,3 @@
-import React from 'react';
-import { mount } from 'enzyme';
 import ProfileGithub from '../ProfileGithub';
 import { githubInfo } from '../../../__mocks__/mockGithubInfo';
 

--- a/client/src/components/profile/__tests__/ProfileHeader.unit.js
+++ b/client/src/components/profile/__tests__/ProfileHeader.unit.js
@@ -1,5 +1,3 @@
-import React from 'react';
-import { shallow } from 'enzyme';
 import ProfileHeader from '../ProfileHeader';
 import { mockProfiles } from '../../../__mocks__/mockProfiles';
 

--- a/client/src/components/profiles/__tests__/ProfileItem.unit.js
+++ b/client/src/components/profiles/__tests__/ProfileItem.unit.js
@@ -1,5 +1,3 @@
-import React from 'react';
-import { shallow  } from 'enzyme';
 import { ProfileItem } from '../ProfileItem';
 import { mockProfiles } from '../../../__mocks__/mockProfiles';
 

--- a/client/src/components/profiles/__tests__/Profiles.int.js
+++ b/client/src/components/profiles/__tests__/Profiles.int.js
@@ -1,5 +1,3 @@
-import React from 'react';
-import { mount } from 'enzyme';
 import { Profiles } from '../Profiles';
 import { mockProfiles, loadingProfile } from '../../../__mocks__/mockProfiles';
 

--- a/client/src/components/profiles/__tests__/Profiles.unit.js
+++ b/client/src/components/profiles/__tests__/Profiles.unit.js
@@ -1,5 +1,3 @@
-import React from 'react';
-import { shallow } from 'enzyme';
 import { Profiles } from '../Profiles';
 import { mockProfiles, noProfiles } from '../../../__mocks__/mockProfiles';
 

--- a/client/src/components/set-profile/__tests__/SetProfile.int.js
+++ b/client/src/components/set-profile/__tests__/SetProfile.int.js
@@ -1,10 +1,7 @@
-import React from 'react';
-import { mount } from 'enzyme';
 import { MemoryRouter } from 'react-router-dom';
 import { Provider } from 'react-redux';
 import ConnectedSetProfile from '../SetProfile';
 import event from '../../../__mocks__/event';
-import { mockStore } from '../../../__mocks__/mockStore';
 
 const profile = {};
 const errors = {};

--- a/client/src/components/set-profile/__tests__/SetProfile.unit.js
+++ b/client/src/components/set-profile/__tests__/SetProfile.unit.js
@@ -1,5 +1,3 @@
-import React from 'react';
-import { shallow } from 'enzyme';
 import { SetProfile } from '../SetProfile';
 
 const createProfile = jest.fn();

--- a/client/src/setupTests.js
+++ b/client/src/setupTests.js
@@ -1,5 +1,7 @@
-import { configure } from 'enzyme';
+import React from 'react';
+import { configure, shallow, render, mount } from 'enzyme';
 import Adapter from 'enzyme-adapter-react-16';
+import { mockStore } from './__mocks__/mockStore';
 configure({ adapter: new Adapter() });
 
 const localStorageMock = {
@@ -9,4 +11,10 @@ const localStorageMock = {
   clear: jest.fn(),
   jwtToken: 'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6IjViZTc3MjMxOGEwZWZhMTFlN2E2ODAxNCIsIm5hbWUiOiJPaXPDrW4gRm9sZXkiLCJhdmF0YXIiOiJodHRwczovL2FuZ2VsLmNvL2Nkbi1jZ2kvaW1hZ2Uvd2lkdGg9MjAwLGhlaWdodD0yMDAsZm9ybWF0PWF1dG8sZml0PWNvdmVyL2h0dHBzOi8vZDFxYjJuYjVjem5hdHUuY2xvdWRmcm9udC5uZXQvdXNlcnMvMjA5NDkzMi1vcmlnaW5hbD8xNTYzNzI1OTgyIiwiaWF0IjoxNTYzODE5NDUxLCJleHAiOjE1NjM4MjMwNTF9.iHngRNoz-WinG9GNVMYWq1-y0H0hao29G5DxwLklEnI'
 };
+
 global.localStorage = localStorageMock;
+global.shallow = shallow;
+global.render = render;
+global.mount = mount;
+global.React = React;
+global.mockStore = mockStore;


### PR DESCRIPTION
Updated /client/src/setupTests.js so that we've globally imported Enzyme's shallow, mount and render components during test startup - along with React - meaning we don't have to import those widely used components in each individual test file.

Many test files within the `/client` directory have therefore been updated to remove the now redundant `import shallow, mount, render` etc. statements within them.